### PR TITLE
Handle missing template paths

### DIFF
--- a/utils/sites.py
+++ b/utils/sites.py
@@ -4,11 +4,34 @@ from utils.config import load_sites_data
 STATIC_TEMPLATES_DIR = 'static/templates'
 
 def get_site_by_name(site_name):
+    """Return site configuration for ``site_name`` if it exists."""
+
     sites = load_sites_data()
     return sites.get(site_name)
 
 def list_site_templates(site_name):
+    """Return HTML templates available for a site.
+
+    Parameters
+    ----------
+    site_name : str
+        Name of the site to look up templates for.
+
+    Returns
+    -------
+    list[str]
+        A list of template file names. If the directory does not exist or
+        cannot be read, an empty list is returned.
+    """
+
     site_template_path = os.path.join(STATIC_TEMPLATES_DIR, site_name)
     if os.path.exists(site_template_path):
-        return [f for f in os.listdir(site_template_path) if f.endswith('.html')]
+        try:
+            return [
+                f
+                for f in os.listdir(site_template_path)
+                if f.endswith('.html')
+            ]
+        except OSError:
+            return []
     return []


### PR DESCRIPTION
## Summary
- enhance helper utilities
  - add docstrings for `get_site_by_name` and `list_site_templates`
  - return an empty list if template directory is missing
  - gracefully handle errors when reading template directories
- ensure `utils/sites.py` ends with a newline

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6863ce0d0fd08331b7ce5f5215591a9f