### PR TITLE
Improve dynamic partial refresh and OCR support

### DIFF
--- a/templates/partials/config.html
+++ b/templates/partials/config.html
@@ -120,10 +120,7 @@
         .then(data => {
             if (data.message) {
                 alert(data.message);
-                // Reload config panel to show updated configuration
-                // This assumes there's a function to reload the config partial
-                // For now, a simple page reload or manual update of DOM might be needed
-                location.reload(); // Simple reload for demonstration
+                loadPartial('config');
             } else {
                 alert('Error: ' + data.error);
             }

--- a/templates/partials/create_site.html
+++ b/templates/partials/create_site.html
@@ -55,18 +55,14 @@ document.getElementById('create-site-form').addEventListener('submit', function(
         },
         body: JSON.stringify(data)
     })
-    .then(response => response.json().then(body => ({ status: response.status, body })))
-    .then(result => {
-        if (result.status === 201) {
+    .then(async response => {
+        const body = await response.json().catch(() => ({}));
+        if (response.status === 201) {
             this.reset();
             document.getElementById('blogger-id').value = generateBlogId();
-            if (typeof loadPartial === 'function') {
-                loadPartial('sites');
-            } else {
-                location.reload();
-            }
+            loadPartial('sites');
         } else {
-            alert(result.body.error || 'Error creating site');
+            alert(body.error || 'Error creating site');
         }
     })
     .catch(err => {

--- a/templates/partials/schedules.html
+++ b/templates/partials/schedules.html
@@ -46,7 +46,7 @@ function editSchedule(scheduleId) {
     .then(res => res.json())
     .then(data => {
         alert(data.message || data.error);
-        if (data.message) location.reload();
+        if (data.message) loadPartial('schedules');
     })
     .catch(err => console.error('Error updating schedule:', err));
 }
@@ -60,10 +60,7 @@ function deleteSchedule(scheduleId) {
         .then(data => {
             if (data.message) {
                 alert(data.message);
-                // Reload schedules to reflect deletion
-                // This assumes there's a function to reload the schedules partial
-                // For now, a simple page reload or manual removal from DOM might be needed
-                location.reload(); // Simple reload for demonstration
+                loadPartial('schedules');
             } else {
                 alert('Error: ' + data.error);
             }

--- a/templates/partials/site_detail.html
+++ b/templates/partials/site_detail.html
@@ -140,15 +140,33 @@ document.getElementById('schedule-source-type').addEventListener('change', e => 
 updateInput('source-input-container', document.getElementById('source-type').value);
 updateInput('schedule-source-input', document.getElementById('schedule-source-type').value);
 
-document.getElementById('post-now-form').addEventListener('submit', function(e) {
+document.getElementById('post-now-form').addEventListener('submit', async function(e) {
     e.preventDefault();
     const inputEl = document.querySelector('#source-input-container input');
+    let sourceInput = '';
+    if (inputEl.type === 'file') {
+        const file = inputEl.files[0];
+        if (!file) { alert('No file selected'); return; }
+        const formData = new FormData();
+        formData.append('file', file);
+        const ocrUrl = document.getElementById('source-type').value === 'pdf' ? '/api/ocr/pdf' : '/api/ocr/image';
+        try {
+            const ocrRes = await fetch(ocrUrl, { method: 'POST', body: formData });
+            const ocrData = await ocrRes.json();
+            if (!ocrRes.ok) { alert(ocrData.error || 'Failed to process file'); return; }
+            sourceInput = ocrData.content;
+        } catch (err) {
+            console.error(err); alert('Failed to process file'); return;
+        }
+    } else {
+        sourceInput = inputEl.value;
+    }
     const data = {
         site_name: document.getElementById('post-site-name').value,
         content_source: document.getElementById('source-type').value,
         ai_model: document.getElementById('ai-model').value,
         template: document.querySelector('input[name="template"]:checked')?.value,
-        source_input: inputEl.type === 'file' ? (inputEl.files[0] ? inputEl.files[0].name : '') : inputEl.value
+        source_input: sourceInput
     };
     fetch('/api/create_post', {
         method: 'POST',
@@ -179,7 +197,10 @@ document.getElementById('schedule-form').addEventListener('submit', function(e) 
         body: JSON.stringify(payload)
     })
     .then(r => r.json())
-    .then(d => alert(d.message || d.error))
+    .then(d => {
+        alert(d.message || d.error);
+        if (d.message) loadPartial('schedules');
+    })
     .catch(err => { console.error(err); alert('Failed to create schedule'); });
 });
 


### PR DESCRIPTION
## Summary
- reload site list after creating a site
- use OCR endpoints when posting from PDF or image
- refresh schedules in place after updates
- reload config view without refreshing the whole page

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6863ce0e9be883318eec2127b9d0c01c