### PR TITLE
Support uploading client secret on site creation

### DIFF
--- a/main.py
+++ b/main.py
@@ -34,11 +34,29 @@ def index():
 @app.route('/api/sites', methods=['GET', 'POST'])
 def api_sites():
     if request.method == 'POST':
-        site_data = request.json
-        site_name = site_data.get('name')
-
+        site_name = request.form.get('name')
         if not site_name:
             return jsonify({'error': 'Site name is required'}), 400
+
+        blog_id = request.form.get('blog_id')
+        api_key = request.form.get('api_key')
+        language = request.form.get('language')
+
+        cred_path = None
+        if 'client_secret' in request.files:
+            file = request.files['client_secret']
+            if file.filename:
+                os.makedirs('config', exist_ok=True)
+                cred_path = os.path.join('config', f'{site_name}_client_secret.json')
+                file.save(cred_path)
+
+        site_data = {
+            'name': site_name,
+            'blog_id': blog_id,
+            'api_key': api_key,
+            'language': language,
+            'client_secret': cred_path,
+        }
 
         sites = load_sites_data()
         sites[site_name] = site_data

--- a/templates/partials/create_site.html
+++ b/templates/partials/create_site.html
@@ -7,11 +7,15 @@
     </div>
     <div class="mb-3">
         <label for="blogger-id" class="form-label">Blogger Blog ID</label>
-        <input type="text" class="form-control" id="blogger-id" readonly>
+        <input type="text" class="form-control" id="blogger-id">
     </div>
     <div class="mb-3">
         <label for="api-key" class="form-label">Blogger API Key</label>
         <input type="text" class="form-control" id="api-key" required>
+    </div>
+    <div class="mb-3">
+        <label for="client-secret" class="form-label">Client Secret</label>
+        <input type="file" class="form-control" id="client-secret" accept=".json">
     </div>
     <div class="mb-3">
         <label for="language" class="form-label">Language</label>
@@ -42,18 +46,20 @@ document.addEventListener('DOMContentLoaded', () => {
 
 document.getElementById('create-site-form').addEventListener('submit', function(e) {
     e.preventDefault();
-    const data = {
-        name: document.getElementById('site-name').value,
-        blog_id: document.getElementById('blogger-id').value,
-        api_key: document.getElementById('api-key').value,
-        language: document.getElementById('language').value
-    };
+
+    const formData = new FormData();
+    formData.append('name', document.getElementById('site-name').value);
+    formData.append('blog_id', document.getElementById('blogger-id').value);
+    formData.append('api_key', document.getElementById('api-key').value);
+    formData.append('language', document.getElementById('language').value);
+    const secretInput = document.getElementById('client-secret');
+    if (secretInput.files.length > 0) {
+        formData.append('client_secret', secretInput.files[0]);
+    }
+
     fetch('/api/sites', {
         method: 'POST',
-        headers: {
-            'Content-Type': 'application/json'
-        },
-        body: JSON.stringify(data)
+        body: formData
     })
     .then(async response => {
         const body = await response.json().catch(() => ({}));


### PR DESCRIPTION
## Summary
- make blog ID field editable
- allow uploading a `client_secret.json` when creating a site
- send site creation form as `FormData`
- store uploaded credentials server-side

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6863e29cae8c833195d0364514d23551