### PR TITLE
Handle site credential uploads

### DIFF
--- a/main.py
+++ b/main.py
@@ -46,16 +46,16 @@ def api_sites():
         if 'client_secret' in request.files:
             file = request.files['client_secret']
             if file.filename:
-                os.makedirs('config', exist_ok=True)
-                cred_path = os.path.join('config', f'{site_name}_client_secret.json')
+                cred_dir = os.path.join('config', site_name)
+                os.makedirs(cred_dir, exist_ok=True)
+                cred_path = os.path.join(cred_dir, 'client_secret.json')
                 file.save(cred_path)
 
         site_data = {
-            'name': site_name,
             'blog_id': blog_id,
             'api_key': api_key,
             'language': language,
-            'client_secret': cred_path,
+            'credential_path': cred_path,
         }
 
         sites = load_sites_data()


### PR DESCRIPTION
## Summary
- save uploaded credentials to a site-specific config directory
- record blog metadata and credential path in `sites_data.json`

## Testing
- `python -m py_compile main.py utils/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863e4496204833196582ec4a8e09f13