### PR TITLE
Add credential helpers

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,13 @@
 from flask import Flask, render_template, request, jsonify
 import os
-from utils.config import load_sites_data, save_sites_data, load_model_config, save_model_config
+from utils.config import (
+    load_sites_data,
+    save_sites_data,
+    load_model_config,
+    save_model_config,
+    get_credentials_dir,
+    save_client_secret,
+)
 from utils.sites import get_site_by_name, list_site_templates
 from utils.post_creator import create_post
 from utils.schedules import (
@@ -42,14 +49,14 @@ def api_sites():
         api_key = request.form.get('api_key')
         language = request.form.get('language')
 
+        cred_dir = get_credentials_dir(site_name)
+        os.makedirs(cred_dir, exist_ok=True)
+
         cred_path = None
         if 'client_secret' in request.files:
             file = request.files['client_secret']
             if file.filename:
-                cred_dir = os.path.join('config', site_name)
-                os.makedirs(cred_dir, exist_ok=True)
-                cred_path = os.path.join(cred_dir, 'client_secret.json')
-                file.save(cred_path)
+                cred_path = save_client_secret(site_name, file)
 
         site_data = {
             'blog_id': blog_id,

--- a/utils/config.py
+++ b/utils/config.py
@@ -34,3 +34,17 @@ def save_model_config(data):
         os.makedirs(CONFIG_DIR)
     with open(MODEL_CONFIG_FILE, 'w') as f:
         json.dump(data, f, indent=4)
+
+
+def get_credentials_dir(site_name):
+    """Return directory path for credentials for a given site."""
+    return os.path.join(CONFIG_DIR, site_name)
+
+
+def save_client_secret(site_name, file_obj):
+    """Save uploaded client secret file for ``site_name`` and return its path."""
+    cred_dir = get_credentials_dir(site_name)
+    os.makedirs(cred_dir, exist_ok=True)
+    cred_path = os.path.join(cred_dir, "client_secret.json")
+    file_obj.save(cred_path)
+    return cred_path


### PR DESCRIPTION
## Summary
- add helper functions for storing credentials
- switch main app to use new utilities

## Testing
- `python -m py_compile main.py utils/config.py`

------
https://chatgpt.com/codex/tasks/task_e_6863e5feed908331afd57eada41efb23