### PR TITLE
Remove Blogger API key field

### DIFF
--- a/templates/partials/create_site.html
+++ b/templates/partials/create_site.html
@@ -10,10 +10,6 @@
         <input type="text" class="form-control" id="blogger-id">
     </div>
     <div class="mb-3">
-        <label for="api-key" class="form-label">Blogger API Key</label>
-        <input type="text" class="form-control" id="api-key" required>
-    </div>
-    <div class="mb-3">
         <label for="client-secret" class="form-label">Client Secret</label>
         <input type="file" class="form-control" id="client-secret" accept=".json">
     </div>
@@ -50,7 +46,6 @@ document.getElementById('create-site-form').addEventListener('submit', function(
     const formData = new FormData();
     formData.append('name', document.getElementById('site-name').value);
     formData.append('blog_id', document.getElementById('blogger-id').value);
-    formData.append('api_key', document.getElementById('api-key').value);
     formData.append('language', document.getElementById('language').value);
     const secretInput = document.getElementById('client-secret');
     if (secretInput.files.length > 0) {


### PR DESCRIPTION
## Summary
- remove Blogger API key input field from create-site form
- stop appending the API key when submitting site creation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863e7b25eb083318995cd76dc347365