### PR TITLE
Remove API key from site creation

### DIFF
--- a/main.py
+++ b/main.py
@@ -46,7 +46,6 @@ def api_sites():
             return jsonify({'error': 'Site name is required'}), 400
 
         blog_id = request.form.get('blog_id')
-        api_key = request.form.get('api_key')
         language = request.form.get('language')
 
         cred_dir = get_credentials_dir(site_name)
@@ -60,7 +59,6 @@ def api_sites():
 
         site_data = {
             'blog_id': blog_id,
-            'api_key': api_key,
             'language': language,
             'credential_path': cred_path,
         }


### PR DESCRIPTION
## Summary
- stop accepting `api_key` for new sites

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6863e8702578833198195701b694314a