### PR TITLE
Add site logo upload field

### DIFF
--- a/templates/partials/create_site.html
+++ b/templates/partials/create_site.html
@@ -14,6 +14,10 @@
         <input type="file" class="form-control" id="client-secret" accept=".json">
     </div>
     <div class="mb-3">
+        <label for="site-logo" class="form-label">Site Logo</label>
+        <input type="file" class="form-control" id="site-logo" accept="image/*">
+    </div>
+    <div class="mb-3">
         <label for="language" class="form-label">Language</label>
         <select id="language" class="form-select">
             <option value="en" selected>English</option>
@@ -50,6 +54,10 @@ document.getElementById('create-site-form').addEventListener('submit', function(
     const secretInput = document.getElementById('client-secret');
     if (secretInput.files.length > 0) {
         formData.append('client_secret', secretInput.files[0]);
+    }
+    const logoInput = document.getElementById('site-logo');
+    if (logoInput.files.length > 0) {
+        formData.append('site_logo', logoInput.files[0]);
     }
 
     fetch('/api/sites', {


### PR DESCRIPTION
## Summary
- allow uploading a site logo in **Create Site** form
- send uploaded logo file in the `FormData` submission

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6863ee9dc73883319038975f0a1f6d05