### PR TITLE
Fix card title fallback when site name missing

### DIFF
--- a/templates/partials/sites.html
+++ b/templates/partials/sites.html
@@ -4,10 +4,10 @@
     <div class="col">
         <div class="card h-100 site-card" onclick="loadSiteDetail('{{ site_name }}')" style="cursor:pointer;">
             {% if site_data.logo %}
-            <img src="{{ site_data.logo }}" class="card-img-top" alt="{{ site_data.name }} logo">
+            <img src="{{ site_data.logo }}" class="card-img-top" alt="{{ site_data.name or site_name }} logo">
             {% endif %}
             <div class="card-body">
-                <h5 class="card-title">{{ site_data.name }}</h5>
+                <h5 class="card-title">{{ site_data.name or site_name }}</h5>
                 <p class="card-text">Language: {{ site_data.language }}</p>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- use `site_data.name or site_name` in site card title and alt text

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6863f15ec644833187bcb434dc04b27c