### PR TITLE
Fix dynamic script execution in partial loads

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -46,7 +46,19 @@
             fetch(url)
                 .then(response => response.text())
                 .then(html => {
-                    document.getElementById('content').innerHTML = html;
+                    const container = document.getElementById('content');
+                    container.innerHTML = html;
+                    const scripts = container.querySelectorAll('script');
+                    scripts.forEach(oldScript => {
+                        const newScript = document.createElement('script');
+                        if (oldScript.src) {
+                            newScript.src = oldScript.src;
+                        } else {
+                            newScript.textContent = oldScript.textContent;
+                        }
+                        document.body.appendChild(newScript);
+                        oldScript.remove();
+                    });
                 })
                 .catch(err => console.error('Error loading partial:', err));
         }

--- a/templates/partials/sites.html
+++ b/templates/partials/sites.html
@@ -20,7 +20,19 @@ function loadSiteDetail(siteName) {
     fetch(`/load/site/${siteName}`)
         .then(response => response.text())
         .then(html => {
-            document.getElementById('site-detail-container').innerHTML = html;
+            const container = document.getElementById('site-detail-container');
+            container.innerHTML = html;
+            const scripts = container.querySelectorAll('script');
+            scripts.forEach(oldScript => {
+                const newScript = document.createElement('script');
+                if (oldScript.src) {
+                    newScript.src = oldScript.src;
+                } else {
+                    newScript.textContent = oldScript.textContent;
+                }
+                document.body.appendChild(newScript);
+                oldScript.remove();
+            });
         })
         .catch(error => console.error('Error loading site detail:', error));
 }


### PR DESCRIPTION
## Summary
- ensure scripts inside dynamically loaded partials execute
- allow site detail view scripts to run when loaded

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863f34907dc8331bcbc441324fbb596