### PR TITLE
Fix trailing whitespace in utils/sites.py

### DIFF
--- a/utils/sites.py
+++ b/utils/sites.py
@@ -32,4 +32,4 @@ def list_site_templates(site_name):
             ]
         except OSError:
             return []
-    return [] 
+    return []


### PR DESCRIPTION
## Summary
- trim trailing whitespace and add newline at EOF

## Testing
- `python -m py_compile utils/sites.py`


------
https://chatgpt.com/codex/tasks/task_e_6863f47cb6788331bed219e0789697ae