### PR TITLE
Fix site cards style and fetch encoding

### DIFF
--- a/templates/partials/sites.html
+++ b/templates/partials/sites.html
@@ -1,8 +1,19 @@
 <!-- partials/sites.html -->
+<style>
+    .site-card {
+        max-width: 18rem;
+        height: 14rem;
+    }
+
+    .site-card img {
+        object-fit: cover;
+        height: 8rem;
+    }
+</style>
 <div class="site-cards-container row row-cols-1 row-cols-sm-2 row-cols-md-3 g-3">
     {% for site_name, site_data in sites.items() %}
     <div class="col">
-        <div class="card h-100 site-card" onclick="loadSiteDetail('{{ site_name }}')" style="cursor:pointer;">
+        <div class="card site-card" onclick="loadSiteDetail('{{ site_name }}')" style="cursor:pointer;">
             {% if site_data.logo %}
             <img src="{{ site_data.logo }}" class="card-img-top" alt="{{ site_data.name or site_name }} logo">
             {% endif %}
@@ -17,7 +28,7 @@
 
 <script>
 function loadSiteDetail(siteName) {
-    fetch(`/load/site/${siteName}`)
+    fetch(`/load/site/${encodeURIComponent(siteName)}`)
         .then(response => response.text())
         .then(html => {
             const container = document.getElementById('site-detail-container');


### PR DESCRIPTION
## Summary
- add styles for `.site-card` and logo images
- ensure fetch URL encodes the site name
- remove `h-100` to keep cards within style height
- ensure newline at the end of `sites.html`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6863f9fa2a3483319f96ab24a259722f