### PR TITLE
Improve site detail routing and card behavior

### DIFF
--- a/main.py
+++ b/main.py
@@ -36,7 +36,14 @@ def log_request_info():
 
 @app.route('/')
 def index():
-    return render_template('index.html')
+    return render_template('index.html', initial_site_name=None)
+
+
+@app.route('/<site_name>')
+def site_page(site_name):
+    if not get_site_by_name(site_name):
+        return render_template('index.html', initial_site_name=None), 404
+    return render_template('index.html', initial_site_name=site_name)
 
 @app.route('/api/sites', methods=['GET', 'POST'])
 def api_sites():

--- a/templates/index.html
+++ b/templates/index.html
@@ -40,6 +40,9 @@
             'schedules': '/load/schedules',
             'config': '/load/config'
         };
+
+        const initialSiteName = "{{ initial_site_name | default('') }}";
+
         function loadPartial(name) {
             const url = urlMap[name];
             if (!url) return;
@@ -47,6 +50,10 @@
                 .then(response => response.text())
                 .then(html => {
                     const container = document.getElementById('content');
+                    const detail = document.getElementById('site-detail-container');
+                    container.style.display = 'block';
+                    detail.style.display = 'none';
+                    detail.innerHTML = '';
                     container.innerHTML = html;
                     const scripts = container.querySelectorAll('script');
                     scripts.forEach(oldScript => {
@@ -62,8 +69,38 @@
                 })
                 .catch(err => console.error('Error loading partial:', err));
         }
+
+        function loadSiteDetail(siteName) {
+            fetch(`/load/site/${encodeURIComponent(siteName)}`)
+                .then(response => response.text())
+                .then(html => {
+                    const detail = document.getElementById('site-detail-container');
+                    const container = document.getElementById('content');
+                    container.style.display = 'none';
+                    detail.style.display = 'block';
+                    detail.innerHTML = html;
+                    const scripts = detail.querySelectorAll('script');
+                    scripts.forEach(oldScript => {
+                        const newScript = document.createElement('script');
+                        if (oldScript.src) {
+                            newScript.src = oldScript.src;
+                        } else {
+                            newScript.textContent = oldScript.textContent;
+                        }
+                        document.body.appendChild(newScript);
+                        oldScript.remove();
+                    });
+                    history.pushState(null, '', `/${encodeURIComponent(siteName)}`);
+                })
+                .catch(error => console.error('Error loading site detail:', error));
+        }
+
         document.addEventListener('DOMContentLoaded', function() {
-            loadPartial('sites');
+            if (initialSiteName) {
+                loadSiteDetail(initialSiteName);
+            } else {
+                loadPartial('sites');
+            }
         });
     </script>
 </body>

--- a/templates/partials/sites.html
+++ b/templates/partials/sites.html
@@ -25,26 +25,3 @@
     </div>
     {% endfor %}
 </div>
-
-<script>
-function loadSiteDetail(siteName) {
-    fetch(`/load/site/${encodeURIComponent(siteName)}`)
-        .then(response => response.text())
-        .then(html => {
-            const container = document.getElementById('site-detail-container');
-            container.innerHTML = html;
-            const scripts = container.querySelectorAll('script');
-            scripts.forEach(oldScript => {
-                const newScript = document.createElement('script');
-                if (oldScript.src) {
-                    newScript.src = oldScript.src;
-                } else {
-                    newScript.textContent = oldScript.textContent;
-                }
-                document.body.appendChild(newScript);
-                oldScript.remove();
-            });
-        })
-        .catch(error => console.error('Error loading site detail:', error));
-}
-</script>


### PR DESCRIPTION
## Summary
- hide site list when showing site details
- add route to load a site directly via `/SITE_ID`
- allow index page to accept an initial site to load

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686289a63d208331a4cdf4013cc0b3b2