### PR TITLE
Fix root page initialization

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -101,7 +101,7 @@
             'config': '/load/config'
         };
 
-        const initialSiteName = "{{ initial_site_name | default('') }}";
+        const initialSiteName = "{{ initial_site_name or '' }}";
 
         function loadPartial(name) {
             const url = urlMap[name];


### PR DESCRIPTION
## Summary
- avoid rendering `None` into `initialSiteName` in `index.html`

## Testing
- `python3 -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6864f594894c8331b6259549dd599b60