### PR TITLE
Fix routing and SPA navigation

### DIFF
--- a/main.py
+++ b/main.py
@@ -39,7 +39,16 @@ def index():
     return render_template('index.html', initial_site_name=None)
 
 
-@app.route('/<site_name>')
+@app.route('/sites')
+@app.route('/create_site')
+@app.route('/schedules')
+@app.route('/config')
+def spa_routes():
+    """Serve the SPA entry point for top-level pages."""
+    return render_template('index.html', initial_site_name=None)
+
+
+@app.route('/sites/<site_name>')
 def site_page(site_name):
     if not get_site_by_name(site_name):
         return render_template('index.html', initial_site_name=None), 404

--- a/templates/index.html
+++ b/templates/index.html
@@ -81,10 +81,10 @@
   <div id="main">
     <div id="sidebar">
       <div class="list-group">
-        <a class="list-group-item" onclick="loadPartial('sites')">📄 Sites List</a>
-        <a class="list-group-item" onclick="loadPartial('create_site')">➕ Create Site</a>
-        <a class="list-group-item" onclick="loadPartial('schedules')">📅 Schedules</a>
-        <a class="list-group-item" onclick="loadPartial('config')">⚙️ Configuration</a>
+        <a class="list-group-item" href="/sites" onclick="event.preventDefault(); loadPartial('sites')">📄 Sites List</a>
+        <a class="list-group-item" href="/create_site" onclick="event.preventDefault(); loadPartial('create_site')">➕ Create Site</a>
+        <a class="list-group-item" href="/schedules" onclick="event.preventDefault(); loadPartial('schedules')">📅 Schedules</a>
+        <a class="list-group-item" href="/config" onclick="event.preventDefault(); loadPartial('config')">⚙️ Configuration</a>
       </div>
     </div>
     <div class="flex-grow-1" style="width:100%;">
@@ -99,6 +99,13 @@
             'create_site': '/load/create_site',
             'schedules': '/load/schedules',
             'config': '/load/config'
+        };
+
+        const routeMap = {
+            'sites': '/sites',
+            'create_site': '/create_site',
+            'schedules': '/schedules',
+            'config': '/config'
         };
 
         const initialSiteName = "{{ initial_site_name or '' }}";
@@ -126,6 +133,7 @@
                         document.body.appendChild(newScript);
                         oldScript.remove();
                     });
+                    history.pushState(null, '', routeMap[name]);
                 })
                 .catch(err => console.error('Error loading partial:', err));
         }
@@ -150,18 +158,33 @@
                         document.body.appendChild(newScript);
                         oldScript.remove();
                     });
-                    history.pushState(null, '', `/${encodeURIComponent(siteName)}`);
+                    history.pushState(null, '', `/sites/${encodeURIComponent(siteName)}`);
                 })
                 .catch(error => console.error('Error loading site detail:', error));
         }
 
-        document.addEventListener('DOMContentLoaded', function() {
-            if (initialSiteName) {
+        function handleRoute() {
+            const path = window.location.pathname;
+            if (path.startsWith('/sites/') && path.split('/').length > 2) {
+                const siteName = decodeURIComponent(path.split('/')[2]);
+                loadSiteDetail(siteName);
+            } else if (path === '/sites') {
+                loadPartial('sites');
+            } else if (path === '/create_site') {
+                loadPartial('create_site');
+            } else if (path === '/schedules') {
+                loadPartial('schedules');
+            } else if (path === '/config') {
+                loadPartial('config');
+            } else if (initialSiteName) {
                 loadSiteDetail(initialSiteName);
             } else {
                 loadPartial('sites');
             }
-        });
+        }
+
+        window.addEventListener('popstate', handleRoute);
+        document.addEventListener('DOMContentLoaded', handleRoute);
     </script>
 </body>
 </html>

--- a/templates/partials/sites.html
+++ b/templates/partials/sites.html
@@ -63,7 +63,7 @@
 
 <div class="site-cards-container">
   {% for site_name, site_data in sites.items() %}
-    <div class="site-card" onclick="loadSiteDetail('{{ site_name }}')">
+    <a class="site-card" href="/sites/{{ site_name }}" onclick="event.preventDefault(); loadSiteDetail('{{ site_name }}')">
       {% if site_data.logo %}
         <img src="{{ site_data.logo }}" alt="{{ site_data.name or site_name }} logo">
       {% else %}
@@ -73,7 +73,7 @@
         <div class="card-title">{{ site_data.name or site_name }}</div>
         <div class="card-text">Language: {{ site_data.language }}</div>
       </div>
-    </div>
+    </a>
   {% endfor %}
 </div>
 


### PR DESCRIPTION
## Summary
- add server routes for SPA paths `/sites`, `/create_site`, `/schedules`, `/config`
- change site pages to `/sites/<site_name>`
- update navigation links and client-side routing logic
- update site list cards to link to unique URLs

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6864fa47f3688331bae9ad1f143e0c0f