### PR TITLE
Add templates page routing

### DIFF
--- a/main.py
+++ b/main.py
@@ -43,6 +43,7 @@ def index():
 @app.route('/create_site')
 @app.route('/schedules')
 @app.route('/config')
+@app.route('/templates')
 def spa_routes():
     """Serve the SPA entry point for top-level pages."""
     return render_template('index.html', initial_site_name=None)
@@ -53,6 +54,12 @@ def site_page(site_name):
     if not get_site_by_name(site_name):
         return render_template('index.html', initial_site_name=None), 404
     return render_template('index.html', initial_site_name=site_name)
+
+@app.route('/templates/<site_name>')
+def templates_page(site_name):
+    if not get_site_by_name(site_name):
+        return render_template('index.html', initial_site_name=None), 404
+    return render_template('index.html', initial_site_name=None)
 
 @app.route('/api/sites', methods=['GET', 'POST'])
 def api_sites():
@@ -142,6 +149,17 @@ def load_sites():
 @app.route('/load/create_site')
 def load_create_site():
     return render_template('partials/create_site.html')
+
+@app.route('/load/templates')
+def load_templates():
+    sites = load_sites_data()
+    return render_template('partials/templates.html', sites=sites)
+
+@app.route('/load/templates/<site_name>')
+def load_site_templates(site_name):
+    site = get_site_by_name(site_name)
+    templates = list_site_templates(site_name)
+    return render_template('partials/site_templates.html', site=site, templates=templates)
 
 @app.route('/api/create_post', methods=['POST'])
 def api_create_post():

--- a/templates/index.html
+++ b/templates/index.html
@@ -85,6 +85,7 @@
         <a class="list-group-item" href="/create_site" onclick="event.preventDefault(); loadPartial('create_site')">➕ Create Site</a>
         <a class="list-group-item" href="/schedules" onclick="event.preventDefault(); loadPartial('schedules')">📅 Schedules</a>
         <a class="list-group-item" href="/config" onclick="event.preventDefault(); loadPartial('config')">⚙️ Configuration</a>
+        <a class="list-group-item" href="/templates" onclick="event.preventDefault(); loadPartial('templates')">🧩 Templates</a>
       </div>
     </div>
     <div class="flex-grow-1" style="width:100%;">
@@ -98,14 +99,16 @@
             'sites': '/load/sites',
             'create_site': '/load/create_site',
             'schedules': '/load/schedules',
-            'config': '/load/config'
+            'config': '/load/config',
+            'templates': '/load/templates'
         };
 
         const routeMap = {
             'sites': '/sites',
             'create_site': '/create_site',
             'schedules': '/schedules',
-            'config': '/config'
+            'config': '/config',
+            'templates': '/templates'
         };
 
         const initialSiteName = "{{ initial_site_name or '' }}";
@@ -163,13 +166,43 @@
                 .catch(error => console.error('Error loading site detail:', error));
         }
 
+        function loadSiteTemplates(siteName) {
+            fetch(`/load/templates/${encodeURIComponent(siteName)}`)
+                .then(response => response.text())
+                .then(html => {
+                    const detail = document.getElementById('site-detail-container');
+                    const container = document.getElementById('content');
+                    container.style.display = 'none';
+                    detail.style.display = 'block';
+                    detail.innerHTML = html;
+                    const scripts = detail.querySelectorAll('script');
+                    scripts.forEach(oldScript => {
+                        const newScript = document.createElement('script');
+                        if (oldScript.src) {
+                            newScript.src = oldScript.src;
+                        } else {
+                            newScript.textContent = oldScript.textContent;
+                        }
+                        document.body.appendChild(newScript);
+                        oldScript.remove();
+                    });
+                    history.pushState(null, '', `/templates/${encodeURIComponent(siteName)}`);
+                })
+                .catch(error => console.error('Error loading site templates:', error));
+        }
+
         function handleRoute() {
             const path = window.location.pathname;
             if (path.startsWith('/sites/') && path.split('/').length > 2) {
                 const siteName = decodeURIComponent(path.split('/')[2]);
                 loadSiteDetail(siteName);
+            } else if (path.startsWith('/templates/') && path.split('/').length > 2) {
+                const siteName = decodeURIComponent(path.split('/')[2]);
+                loadSiteTemplates(siteName);
             } else if (path === '/sites') {
                 loadPartial('sites');
+            } else if (path === '/templates') {
+                loadPartial('templates');
             } else if (path === '/create_site') {
                 loadPartial('create_site');
             } else if (path === '/schedules') {

--- a/templates/partials/site_templates.html
+++ b/templates/partials/site_templates.html
@@ -1,0 +1,105 @@
+<!-- partials/site_templates.html -->
+<style>
+  .site-panel {
+    font-family: "Segoe UI", sans-serif;
+    max-width: 1000px;
+    margin: 40px auto;
+    padding: 20px 30px;
+    background: #fff;
+    border-radius: 10px;
+    box-shadow: 0 4px 10px rgba(0,0,0,0.06);
+  }
+
+  .site-panel h2 {
+    font-size: 24px;
+    color: #2c3e50;
+    margin-bottom: 10px;
+    border-left: 5px solid #007acc;
+    padding-left: 10px;
+  }
+
+  .site-panel h3 {
+    font-size: 20px;
+    margin-top: 40px;
+    margin-bottom: 15px;
+    color: #007acc;
+  }
+
+  #existing-templates-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px;
+    margin-top: 10px;
+  }
+
+  .site-panel iframe {
+    width: 120px;
+    height: 80px;
+    border: 1px solid #ccc;
+    border-radius: 6px;
+    margin-bottom: 5px;
+  }
+
+  .site-panel button {
+    background-color: #007acc;
+    color: #fff;
+    border: none;
+    padding: 12px 18px;
+    font-size: 16px;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: background-color 0.2s ease-in-out;
+  }
+
+  .site-panel button:hover {
+    background-color: #005fa3;
+  }
+
+  .text-center {
+    text-align: center;
+  }
+</style>
+
+<div class="site-panel">
+  <h2>{{ site.name }} Templates</h2>
+
+  <h3>Upload New Template</h3>
+  <form id="upload-template-form" enctype="multipart/form-data">
+    <input type="hidden" name="site_name" value="{{ site.name }}">
+    <input type="file" name="template_file" accept=".html">
+    <button type="submit">Upload Template</button>
+  </form>
+
+  <h3>Existing Templates</h3>
+  <div id="existing-templates-list">
+    {% for template in templates %}
+    <div class="text-center">
+      <iframe src="{{ url_for('static', filename='templates/' + site.name + '/' + template) }}"></iframe>
+      <div>{{ template }}</div>
+    </div>
+    {% else %}
+    <p>No templates uploaded yet.</p>
+    {% endfor %}
+  </div>
+</div>
+
+<script>
+document.getElementById('upload-template-form').addEventListener('submit', function(event) {
+    event.preventDefault();
+    const formData = new FormData(this);
+    fetch('/api/upload_template', {
+        method: 'POST',
+        body: formData
+    })
+    .then(response => response.json())
+    .then(data => {
+        if (data.message) {
+            alert(data.message);
+            loadSiteTemplates('{{ site.name }}');
+        } else {
+            alert('Error: ' + data.error);
+        }
+    })
+    .catch(error => console.error('Error uploading template:', error));
+});
+</script>

--- a/templates/partials/templates.html
+++ b/templates/partials/templates.html
@@ -1,0 +1,78 @@
+<!-- partials/templates.html -->
+<style>
+  .site-cards-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px;
+    justify-content: center;
+    max-width: 1200px;
+    margin: 30px auto;
+    padding: 10px 20px;
+    font-family: "Segoe UI", sans-serif;
+  }
+
+  .site-card {
+    width: 260px;
+    height: 220px;
+    background: #ffffff;
+    border-radius: 10px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    cursor: pointer;
+    transition: transform 0.2s ease-in-out, box-shadow 0.2s;
+  }
+
+  .site-card:hover {
+    transform: translateY(-6px);
+    box-shadow: 0 6px 12px rgba(0, 0, 0, 0.1);
+  }
+
+  .site-card img {
+    width: 100%;
+    height: 120px;
+    object-fit: cover;
+    background-color: #f0f0f0;
+  }
+
+  .site-card .card-body {
+    padding: 12px 15px;
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    text-align: center;
+  }
+
+  .site-card .card-title {
+    font-size: 16px;
+    font-weight: 600;
+    color: #2c3e50;
+    margin-bottom: 6px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .site-card .card-text {
+    font-size: 14px;
+    color: #666;
+  }
+</style>
+
+<div class="site-cards-container">
+  {% for site_name, site_data in sites.items() %}
+    <a class="site-card" href="/templates/{{ site_name }}" onclick="event.preventDefault(); loadSiteTemplates('{{ site_name }}')">
+      {% if site_data.logo %}
+        <img src="{{ site_data.logo }}" alt="{{ site_data.name or site_name }} logo">
+      {% else %}
+        <img src="https://via.placeholder.com/260x120?text=No+Logo" alt="Default logo">
+      {% endif %}
+      <div class="card-body">
+        <div class="card-title">{{ site_data.name or site_name }}</div>
+        <div class="card-text">Language: {{ site_data.language }}</div>
+      </div>
+    </a>
+  {% endfor %}
+</div>


### PR DESCRIPTION
## Summary
- add Templates link to sidebar
- map templates URLs for partials
- support `/templates` and `/templates/<site>` routes
- add HTML partials for templates list and per-site templates

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_68651617df9c83318ab2288c6154871a