### PR TITLE
Dynamic AI provider dropdown

### DIFF
--- a/config/ai_config.example.json
+++ b/config/ai_config.example.json
@@ -1,4 +1,13 @@
 {
-    "provider": "Gemini",
-    "api_key": "YOUR_API_KEY"
+    "providers": {
+        "gemini": {
+            "model": "gemini-2.5-pro",
+            "api_key": "YOUR_GEMINI_API_KEY"
+        },
+        "openai": {
+            "model": "gpt-4o",
+            "api_key": "YOUR_OPENAI_API_KEY"
+        }
+    }
 }
+

--- a/main.py
+++ b/main.py
@@ -333,6 +333,14 @@ def api_config():
     save_ai_config({"providers": providers_cfg})
     return jsonify({"message": f"Configuration saved for {provider}"}), 200
 
+
+@app.route('/api/providers', methods=['GET'])
+def api_providers():
+    """Return configured AI providers from ``ai_config.json``."""
+    cfg = load_ai_config()
+    providers = cfg.get("providers", {})
+    return jsonify(providers)
+
 @app.route('/api/ocr/pdf', methods=['POST'])
 def api_ocr_pdf():
     if 'file' not in request.files:

--- a/templates/partials/site_detail.html
+++ b/templates/partials/site_detail.html
@@ -107,7 +107,9 @@
 
     <div class="mb-3">
       <label for="ai-provider">AI Provider</label>
-      <select id="ai-provider" name="ai_provider" required></select>
+      <select id="ai-provider" name="ai_provider" required>
+        <option disabled selected>Loading...</option>
+      </select>
     </div>
 
     <div class="mb-3">
@@ -145,8 +147,25 @@
 </div>
 
 <script type="text/javascript">
-  const savedConfigs = JSON.parse(`{{ ai_config | tojson | safe }}`);
-  console.log("✅ Loaded savedConfigs:", savedConfigs);
+  // Initialize config only once to avoid duplicate variable errors when
+  // this partial is loaded multiple times via the SPA navigation.
+  if (!window.siteDetailConfigs) {
+    window.siteDetailConfigs = JSON.parse(`{{ ai_config | tojson | safe }}`);
+  }
+  let savedConfigs = window.siteDetailConfigs;
+
+  async function refreshProviders() {
+    try {
+      const res = await fetch('/api/providers');
+      if (res.ok) {
+        const providers = await res.json();
+        savedConfigs = { providers };
+        window.siteDetailConfigs = savedConfigs;
+      }
+    } catch (err) {
+      console.error('⚠️ Failed to load providers:', err);
+    }
+  }
 
   function updateInputField() {
     const container = document.getElementById('source-input-container');
@@ -220,20 +239,22 @@
     }
   }
 
-  document.addEventListener('DOMContentLoaded', () => {
-    console.log("📦 DOM loaded, initializing form...");
-    updateInputField();
-    populateProvidersAndModels();
-  });
+  if (!window.siteDetailEventsBound) {
+    document.addEventListener('DOMContentLoaded', async () => {
+      console.log("📦 DOM loaded, initializing form...");
+      await refreshProviders();
+      updateInputField();
+      populateProvidersAndModels();
+    });
 
-  document.getElementById('ai-provider').addEventListener('change', () => {
-    console.log("🔄 Provider changed");
-    updateModelOptions();
-  });
+    document.getElementById('ai-provider').addEventListener('change', () => {
+      console.log("🔄 Provider changed");
+      updateModelOptions();
+    });
 
   document.getElementById('schedule-form').addEventListener('submit', async function (e) {
-    e.preventDefault();
-    console.log("🚀 Submitting schedule form...");
+      e.preventDefault();
+      console.log("🚀 Submitting schedule form...");
 
     const inputEl = document.querySelector('#source-input-container input');
     let sourceInput = '';
@@ -295,4 +316,6 @@
       alert('Failed to create schedule');
     });
   });
+    window.siteDetailEventsBound = true;
+  }
 </script>

--- a/utils/config.py
+++ b/utils/config.py
@@ -5,6 +5,7 @@ CONFIG_DIR = 'config'
 SITES_DATA_FILE = os.path.join(CONFIG_DIR, 'sites_data.json')
 # Store global AI provider and API key
 AI_CONFIG_FILE = os.path.join(CONFIG_DIR, 'ai_config.json')
+AI_CONFIG_EXAMPLE_FILE = os.path.join(CONFIG_DIR, 'ai_config.example.json')
 
 def load_sites_data():
     if not os.path.exists(CONFIG_DIR):
@@ -21,14 +22,29 @@ def save_sites_data(data):
     with open(SITES_DATA_FILE, 'w') as f:
         json.dump(data, f, indent=4)
 
+def _initialize_ai_config():
+    """Create ``AI_CONFIG_FILE`` using the example file if available."""
+    if os.path.exists(AI_CONFIG_EXAMPLE_FILE):
+        try:
+            with open(AI_CONFIG_EXAMPLE_FILE, "r") as src:
+                data = json.load(src)
+        except Exception:
+            data = {"providers": {}}
+    else:
+        data = {"providers": {}}
+
+    with open(AI_CONFIG_FILE, "w") as f:
+        json.dump(data, f, indent=4)
+    return data
+
+
 def load_ai_config():
     """Load global AI provider configuration with safe fallback."""
     if not os.path.exists(CONFIG_DIR):
         os.makedirs(CONFIG_DIR)
 
     if not os.path.exists(AI_CONFIG_FILE):
-        with open(AI_CONFIG_FILE, 'w') as f:
-            json.dump({"providers": {}}, f)
+        return _initialize_ai_config()
 
     try:
         with open(AI_CONFIG_FILE, 'r') as f:
@@ -38,9 +54,7 @@ def load_ai_config():
             return json.loads(content)
     except json.JSONDecodeError:
         # Corrupted or empty file — reset to defaults
-        with open(AI_CONFIG_FILE, 'w') as f:
-            json.dump({"providers": {}}, f)
-        return {"providers": {}}
+        return _initialize_ai_config()
 
 def save_ai_config(data):
     """Persist global AI provider configuration."""


### PR DESCRIPTION
## Summary
- load providers from example config if ai_config.json missing
- update example config to use new provider structure
- maintain dynamic provider dropdown logic in `site_detail.html`

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_686fbf4605088331bd18f7eff078b03d